### PR TITLE
fixed main files in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,10 @@
     "Nanang Mahdaen El Agung <nanang@mahdaen.name>"
   ],
   "description": "Angular Icon - Ionicon",
-  "main": "index.js",
+  "main": [
+    "angularic-ionicon.js",
+    "angularic-ionicon.css"
+  ],
   "keywords": [
     "angular",
     "icon",


### PR DESCRIPTION
@mahdaen I tried installing the module with bower to find out that the ```main``` property in ```bower.json``` has a wrong value. (see [here](https://github.com/cobolab/ionicon/blob/master/bower.json#L8))

Therefore the ```wiredep:js``` and ```wiredep:css``` task of the ```grunt-wiredep```module is not able to include properly the source files.

I fixed the ```main```property to include the correct files. (see [here](https://github.com/circleback/ionicon/blob/fix_bower_main/bower.json#L8-L10))